### PR TITLE
sys/net/routing/rpl: bypass path cost calculation

### DIFF
--- a/sys/net/routing/rpl/of_mrhof.c
+++ b/sys/net/routing/rpl/of_mrhof.c
@@ -62,6 +62,9 @@ static uint16_t calc_path_cost(rpl_parent_t *parent)
 {
     DEBUGF("calc_pathcost\n");
 
+    puts("[EVIL HACK] What goes around, comes around.");
+    return DEFAULT_MIN_HOP_RANK_INCREASE;
+
     /*
      * Calculates the path cost through the parent, for now, only for ETX
      */


### PR DESCRIPTION
When PR [#2431](https://github.com/RIOT-OS/RIOT/pull/2431) is merged in RIOT master we will needd this `[EVIL HACK]`  for calculating a proper RPL node `rank` until the [`of_mrhof::calc_path_cost()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/routing/rpl/of_mrhof.c#L75) provides reasonable values for the `rank` calculation.

Rationale:
The [`etx_beaconing::etx_get_metric()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/routing/etx_beaconing.c#L271) call does not provide a reasonable value when used by  [`of_mrhof::calc_path_cost()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/routing/rpl/of_mrhof.c#L75). 
This results in a wrong path cost calculation and eventually in an [`INFINITE_RANK`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/rpl/rpl_config.h#L119) for the RPL node, isolating it as a leaf node, i.e. the node cannot be a router/parent.
