### PR TITLE
microcoap: add patch to increment MAX_SEGMENTS

### DIFF
--- a/pkg/microcoap/0004-increment_max_segments.patch
+++ b/pkg/microcoap/0004-increment_max_segments.patch
@@ -1,0 +1,25 @@
+From 56dd59b911055fa045738d74e9aa5089dc37a0e5 Mon Sep 17 00:00:00 2001
+From: Lotte Steenbrink <lotte@zombietetris.de>
+Date: Tue, 17 Mar 2015 10:42:02 -0700
+Subject: [PATCH] increment MAX_SEGMENTS
+
+---
+ coap.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/coap.h b/coap.h
+index 9090285..6839846 100644
+--- a/coap.h
++++ b/coap.h
+@@ -131,7 +131,7 @@ typedef enum
+ ///////////////////////
+ 
+ typedef int (*coap_endpoint_func)(coap_rw_buffer_t *scratch, const coap_packet_t *inpkt, coap_packet_t *outpkt, uint8_t id_hi, uint8_t id_lo);
+-#define MAX_SEGMENTS 2  // 2 = /foo/bar, 3 = /foo/bar/baz
++#define MAX_SEGMENTS 3  // 2 = /foo/bar, 3 = /foo/bar/baz
+ typedef struct
+ {
+     int count;
+-- 
+1.9.1
+


### PR DESCRIPTION
Increment MAX_SEGMENTS because we need more. 
DO NOT MERGE INTO MASTER, but use this if you want to compile the plant_node app.
